### PR TITLE
Submission List View

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import CreateTeams from "pages/Assignments/CreateTeams";
 import ViewDelayedJobs from "pages/Assignments/ViewDelayedJobs";
 import ViewReports from "pages/Assignments/ViewReports";
 import ViewScores from "pages/Assignments/ViewScores";
-import ViewSubmissions from "pages/Assignments/ViewSubmissions";
 import Courses from "pages/Courses/Course";
 import CourseEditor from "pages/Courses/CourseEditor";
 import { loadCourseInstructorDataAndInstitutions } from "pages/Courses/CourseUtil";
@@ -17,6 +16,7 @@ import { loadParticipantDataRolesAndInstitutions } from "pages/Participants/part
 import EditProfile from "pages/Profile/Edit";
 import Reviews from "pages/Reviews/reviews";
 import SubmissionsView from "pages/Submissions/SubmissionsView";
+import SubmissionView from "pages/Submissions/SubmissionView";
 import TA from "pages/TA/TA";
 import TAEditor from "pages/TA/TAEditor";
 import { loadTAs } from "pages/TA/TAUtil";
@@ -72,7 +72,7 @@ function App() {
         },
         {
           path: "assignments/edit/:id/viewsubmissions",
-          element: <ViewSubmissions />,
+          element: <SubmissionView />,
           loader: loadAssignment,
         },
         {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,45 +1,45 @@
-import React from "react";
+import RootLayout from "layout/Root";
+import { loadAssignment } from "pages/Assignments/AssignmentUtil";
+import AssignReviewer from "pages/Assignments/AssignReviewer";
+import CreateTeams from "pages/Assignments/CreateTeams";
+import ViewDelayedJobs from "pages/Assignments/ViewDelayedJobs";
+import ViewReports from "pages/Assignments/ViewReports";
+import ViewScores from "pages/Assignments/ViewScores";
+import ViewSubmissions from "pages/Assignments/ViewSubmissions";
+import Courses from "pages/Courses/Course";
+import CourseEditor from "pages/Courses/CourseEditor";
+import { loadCourseInstructorDataAndInstitutions } from "pages/Courses/CourseUtil";
+import Questionnaire from "pages/EditQuestionnaire/Questionnaire";
+import Home from "pages/Home";
+import Participants from "pages/Participants/Participant";
+import ParticipantEditor from "pages/Participants/ParticipantEditor";
+import { loadParticipantDataRolesAndInstitutions } from "pages/Participants/participantUtil";
+import EditProfile from "pages/Profile/Edit";
+import Reviews from "pages/Reviews/reviews";
+import SubmissionsView from "pages/Submissions/SubmissionsView";
+import TA from "pages/TA/TA";
+import TAEditor from "pages/TA/TAEditor";
+import { loadTAs } from "pages/TA/TAUtil";
 import { createBrowserRouter, Navigate, RouterProvider } from "react-router-dom";
 import AdministratorLayout from "./layout/Administrator";
 import ManageUserTypes, { loader as loadUsers } from "./pages/Administrator/ManageUserTypes";
+import Assignment from "./pages/Assignments/Assignment";
+import AssignmentEditor from "./pages/Assignments/AssignmentEditor";
 import Login from "./pages/Authentication/Login";
 import Logout from "./pages/Authentication/Logout";
+import Email_the_author from "./pages/Email_the_author/email_the_author";
 import InstitutionEditor, { loadInstitution } from "./pages/Institutions/InstitutionEditor";
 import Institutions, { loadInstitutions } from "./pages/Institutions/Institutions";
 import RoleEditor, { loadAvailableRole } from "./pages/Roles/RoleEditor";
 import Roles, { loadRoles } from "./pages/Roles/Roles";
-import Assignment from "./pages/Assignments/Assignment";
-import AssignmentEditor from "./pages/Assignments/AssignmentEditor";
-import { loadAssignment } from "pages/Assignments/AssignmentUtil";
+import Users from "./pages/Users/User";
+import UserEditor from "./pages/Users/UserEditor";
+import { loadUserDataRolesAndInstitutions } from "./pages/Users/userUtil";
+import ReviewTable from "./pages/ViewTeamGrades/ReviewTable";
 import ErrorPage from "./router/ErrorPage";
+import NotFound from "./router/NotFound";
 import ProtectedRoute from "./router/ProtectedRoute";
 import { ROLE } from "./utils/interfaces";
-import NotFound from "./router/NotFound";
-import Participants from "pages/Participants/Participant";
-import ParticipantEditor from "pages/Participants/ParticipantEditor";
-import { loadParticipantDataRolesAndInstitutions } from "pages/Participants/participantUtil";
-import RootLayout from "layout/Root";
-import UserEditor from "./pages/Users/UserEditor";
-import Users from "./pages/Users/User";
-import { loadUserDataRolesAndInstitutions } from "./pages/Users/userUtil";
-import Home from "pages/Home";
-import Questionnaire from "pages/EditQuestionnaire/Questionnaire";
-import Courses from "pages/Courses/Course";
-import CourseEditor from "pages/Courses/CourseEditor";
-import { loadCourseInstructorDataAndInstitutions } from "pages/Courses/CourseUtil";
-import TA from "pages/TA/TA";
-import TAEditor from "pages/TA/TAEditor";
-import { loadTAs } from "pages/TA/TAUtil";
-import ReviewTable from "./pages/ViewTeamGrades/ReviewTable";
-import EditProfile from "pages/Profile/Edit";
-import Reviews from "pages/Reviews/reviews";
-import Email_the_author from "./pages/Email_the_author/email_the_author";
-import CreateTeams from "pages/Assignments/CreateTeams";
-import AssignReviewer from "pages/Assignments/AssignReviewer";
-import ViewSubmissions from "pages/Assignments/ViewSubmissions";
-import ViewScores from "pages/Assignments/ViewScores";
-import ViewReports from "pages/Assignments/ViewReports";
-import ViewDelayedJobs from "pages/Assignments/ViewDelayedJobs";
 function App() {
   const router = createBrowserRouter([
     {
@@ -121,6 +121,10 @@ function App() {
               loader: loadUserDataRolesAndInstitutions,
             },
           ],
+        },
+        {
+          path: "student_tasks",
+          element: <ProtectedRoute element={<SubmissionsView />} leastPrivilegeRole={ROLE.TA} />,
         },
         {
           path: "student_tasks/participants",

--- a/src/pages/Submissions/SubmissionTable/SubmissionEntry.test.tsx
+++ b/src/pages/Submissions/SubmissionTable/SubmissionEntry.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import SubmissionList from './SubmissionList';
+
+const mockSubmissions = [
+  {
+    id: 1,
+    teamName: 'Anonymized_Team_38121',
+    assignment: 'Assignment 1',
+    members: [{ name: 'Student 1', id: 1 }],
+    links: [],
+    fileInfo: [],
+  },
+];
+
+const mockOnGradeClick = jest.fn();
+
+describe('SubmissionEntry', () => {
+  it('displays the correct team name', () => {
+    render(
+      <BrowserRouter>
+        <SubmissionList submissions={mockSubmissions} onGradeClick={mockOnGradeClick} />
+      </BrowserRouter>
+    );
+    
+    // Check if team name is rendered correctly
+    expect(screen.getByText('Anonymized_Team_38121')).toBeTruthy();
+  });
+
+  it('calls onGradeClick when the grade button is clicked', () => {
+    render(
+      <BrowserRouter>
+        <SubmissionList submissions={mockSubmissions} onGradeClick={mockOnGradeClick} />
+      </BrowserRouter>
+    );
+    
+    // Simulate the button click
+    const button = screen.getByRole('button', { name: /Assign Grade/i });
+    fireEvent.click(button);
+
+    expect(mockOnGradeClick).toHaveBeenCalledWith(mockSubmissions[0].id);
+  });
+});

--- a/src/pages/Submissions/SubmissionTable/SubmissionEntry.tsx
+++ b/src/pages/Submissions/SubmissionTable/SubmissionEntry.tsx
@@ -1,0 +1,116 @@
+import { createColumnHelper } from "@tanstack/react-table";
+import { Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
+
+interface ISubmissionEntry {
+  id: number;
+  teamName: string;
+  assignment: string;
+  members: { name: string; id: number }[];
+  links: { url: string; displayName: string }[];
+  fileInfo: { name: string; size: string; dateModified: string }[];
+}
+
+const columnHelper = createColumnHelper<ISubmissionEntry>();
+
+const SubmissionEntry = ({ onGradeClick }: { onGradeClick: (id: number) => void }) => {
+  const columns = [
+    // Team Name column: Sorting enabled, search disabled
+    columnHelper.accessor('teamName', {
+      header: ({ column }) => (
+        <div
+          onClick={column.getToggleSortingHandler()} // Toggle sorting on click
+          style={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}
+        >
+          Team Name
+          {
+            !column.getIsSorted() && <span> ⬍</span>
+          }
+        </div>
+      ),
+      cell: (info) => (
+        <>
+          <div>{info.getValue()}</div>
+          <Button variant="link" onClick={() => onGradeClick(info.row.original.id)}>
+            Assign Grade
+          </Button>
+        </>
+      ),
+      size: 25,
+      enableSorting: true,
+      enableColumnFilter: false, 
+      enableGlobalFilter: false,
+    }),
+
+    // Team Members column: No search, no sorting
+    columnHelper.accessor('members', {
+      header: () => 'Team Members',
+      cell: (info) =>
+        info.getValue().map((member) => (
+          <div key={member.id}>
+            <Link to={`/profile/${member.id}`}>
+              {member.name} (Student {member.id})
+            </Link>
+          </div>
+        )),
+      size: 35,
+      enableSorting: false,
+      enableColumnFilter: false, 
+      enableGlobalFilter: false, 
+    }),
+
+    // Links column: No search, no sorting
+    columnHelper.accessor('links', {
+      header: () => 'Links',
+      cell: (info) => (
+        <div>
+          {info.getValue().map((link, idx) => (
+            <div key={idx}>
+              <a href={link.url}>{link.displayName}</a>
+            </div>
+          ))}
+        </div>
+      ),
+      size: 15,
+      enableSorting: false,
+      enableColumnFilter: false,
+      enableGlobalFilter: false,
+    }),
+
+    // File Info column: No search, no sorting
+    columnHelper.accessor('fileInfo', {
+      header: () => 'File Info',
+      cell: (info) => (
+        <div>
+          {info.getValue().map((file, idx) => (
+            <div key={idx}>
+              <div>{file.name}</div>
+              <div>Size: {file.size}</div>
+              <div>Date Modified: {file.dateModified}</div>
+            </div>
+          ))}
+        </div>
+      ),
+      size: 25,
+      enableSorting: false,
+      enableColumnFilter: false,
+      enableGlobalFilter: false,
+    }),
+
+    // History column: Links to history pages (No search or sorting)
+    columnHelper.display({
+      id: 'history',
+      header: () => 'History',
+      cell: (info) => (
+        <Link to={`/history/${info.row.original.id}`}>History</Link>
+      ),
+      enableSorting: false,
+      enableColumnFilter: false,
+      enableGlobalFilter: false,
+    }),
+  ];
+
+  return columns;
+};
+
+export default SubmissionEntry;

--- a/src/pages/Submissions/SubmissionTable/SubmissionList.test.tsx
+++ b/src/pages/Submissions/SubmissionTable/SubmissionList.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import SubmissionList from './SubmissionList';
+
+const mockSubmissions = [
+  {
+    id: 1,
+    teamName: 'Team B',
+    assignment: 'Assignment 1',
+    members: [{ name: 'Student 1', id: 1 }],
+    links: [],
+    fileInfo: [],
+  },
+  {
+    id: 2,
+    teamName: 'Team A',
+    assignment: 'Assignment 1',
+    members: [{ name: 'Student 2', id: 2 }],
+    links: [],
+    fileInfo: [],
+  },
+];
+
+const mockOnGradeClick = jest.fn();
+
+describe('SubmissionList', () => {
+  it('renders submission entries correctly', () => {
+    render(
+      <BrowserRouter>
+        <SubmissionList submissions={mockSubmissions} onGradeClick={mockOnGradeClick} />
+      </BrowserRouter>
+    );
+
+    // Check if submission entry is rendered
+    expect(screen.getByText('Team B')).toBeTruthy();
+    expect(screen.getByText('Team A')).toBeTruthy();
+  });
+
+  it('sorts the submissions by team name', () => {
+    render(
+      <BrowserRouter>
+        <SubmissionList submissions={mockSubmissions} onGradeClick={mockOnGradeClick} />
+      </BrowserRouter>
+    );
+  
+    // Click the team name header to sort ascending
+    const teamNameHeader = screen.getByText('Team Name');
+    fireEvent.click(teamNameHeader);
+  
+    // Get the rows that contain submission entries
+    const rows = screen.getAllByRole('row');
+  
+    // Check the order of the first two submission rows (excluding the header)
+    expect(rows[1].innerHTML).toContain('Team A'); 
+    expect(rows[2].innerHTML).toContain('Team B');
+  
+    // Click again to sort descending
+    fireEvent.click(teamNameHeader);
+  
+    // Get the rows again after sorting
+    const sortedRows = screen.getAllByRole('row');
+  
+    // Check the order of the first two submission rows (excluding the header)
+    expect(sortedRows[1].innerHTML).toContain('Team B');
+    expect(sortedRows[2].innerHTML).toContain('Team A'); 
+  });
+  
+});

--- a/src/pages/Submissions/SubmissionTable/SubmissionList.tsx
+++ b/src/pages/Submissions/SubmissionTable/SubmissionList.tsx
@@ -1,0 +1,22 @@
+import Table from "components/Table/Table";
+import { useMemo } from "react";
+import SubmissionEntry from "./SubmissionEntry";
+
+const SubmissionList = ({ submissions, onGradeClick }: { submissions: any[], onGradeClick: (id: number) => void }) => {
+  
+  const columns = useMemo(() => SubmissionEntry({ onGradeClick }), [onGradeClick]);
+
+  return (
+    <div className="table-container" style={{ width: "100%", overflowX: "auto" }}>
+      <Table
+        data={submissions}
+        columns={columns}
+        columnVisibility={{
+          id: false,
+        }}
+      />
+    </div>
+  );
+};
+
+export default SubmissionList;

--- a/src/pages/Submissions/SubmissionView.tsx
+++ b/src/pages/Submissions/SubmissionView.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
-import { Button, Container, Row, Col } from 'react-bootstrap';
+import { Button, Col, Container, Row } from 'react-bootstrap';
 // import { useNavigate } from 'react-router-dom';
-import Table from "components/Table/Table";
 import { createColumnHelper } from "@tanstack/react-table";
+import Table from "components/Table/Table";
 import { useLoaderData } from 'react-router-dom';
 
 interface ISubmission {
@@ -12,7 +12,7 @@ interface ISubmission {
 
 const columnHelper = createColumnHelper<ISubmission>();
 
-const ViewSubmissions: React.FC = () => {
+const SubmissionView: React.FC = () => {
   const assignment: any = useLoaderData();
   // const navigate = useNavigate();
 
@@ -81,4 +81,4 @@ const ViewSubmissions: React.FC = () => {
   );
 };
 
-export default ViewSubmissions;
+export default SubmissionView;

--- a/src/pages/Submissions/SubmissionsView.test.tsx
+++ b/src/pages/Submissions/SubmissionsView.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import SubmissionView from './SubmissionsView';
+
+describe('SubmissionsView', () => {
+    it('renders the title and filter', () => {
+        render(
+          <BrowserRouter>
+            <SubmissionView />
+          </BrowserRouter>
+        );
+    
+        const title = screen.getByText('Submissions');
+        const filter = screen.getByLabelText('Filter by Assignment');
+    
+        expect(title).toBeTruthy();
+        expect(filter).toBeTruthy();
+      });
+
+      it('filters submissions based on selected assignment', async () => {
+        render(
+          <BrowserRouter>
+            <SubmissionView />
+          </BrowserRouter>
+        );
+    
+        // Select an assignment to filter
+        const select = screen.getByLabelText('Filter by Assignment');
+        fireEvent.change(select, { target: { value: 'Assignment 1' } });
+    
+        // Check if the filtered submission is displayed
+        expect(await screen.findByText('Anonymized_Team_38121')).toBeTruthy();
+        expect(screen.queryByText('Anonymized_Team_38122')).toBeFalsy();
+      });
+    
+      it('shows all submissions when no filter is applied', async () => {
+        render(
+          <BrowserRouter>
+            <SubmissionView />
+          </BrowserRouter>
+        );
+    
+        // Select an assignment to filter
+        const select = screen.getByLabelText('Filter by Assignment');
+        fireEvent.change(select, { target: { value: 'Assignment 1' } });
+    
+        // Reset filter
+        fireEvent.change(select, { target: { value: '' } });
+    
+        // Check if all submissions are displayed
+        expect(await screen.findByText('Anonymized_Team_38121')).toBeTruthy();
+        expect(await screen.findByText('Anonymized_Team_38122')).toBeTruthy();
+      });
+});

--- a/src/pages/Submissions/SubmissionsView.tsx
+++ b/src/pages/Submissions/SubmissionsView.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { Col, Container, Form, Row } from "react-bootstrap";
+import SubmissionList from "./SubmissionTable/SubmissionList";
+
+const SubmissionView = () => {
+  const [submissions, setSubmissions] = useState<any[]>([]);
+  const [filteredSubmissions, setFilteredSubmissions] = useState<any[]>([]);
+  const [assignmentFilter, setAssignmentFilter] = useState<string>("");
+
+  // Dummy assignments for filtering
+  const assignments = ["Assignment 1", "Assignment 2", "Assignment 3"];
+
+  useEffect(() => {
+    // Simulating data fetching
+    const fetchSubmissions = async () => {
+      const data = [
+        {
+          id: 1,
+          teamName: "Anonymized_Team_38121",
+          assignment: "Assignment 1",
+          members: [
+            { name: "Student 10566", id: 10566 },
+            { name: "Student 10559", id: 10559 },
+            { name: "Student 10359", id: 10359 },
+          ],
+          links: [
+            { url: "https://github.com/example/repo", displayName: "GitHub Repository" },
+            { url: "http://google.com", displayName: "Submission Link" },
+          ],
+          fileInfo: [
+            { name: "README.md", size: "14.9 KB", dateModified: "2024-10-03 23:36:57" },
+          ],
+        },
+        {
+          id: 2,
+          teamName: "Anonymized_Team_38122",
+          assignment: "Assignment 2",
+          members: [
+            { name: "Student 10593", id: 10593 },
+            { name: "Student 10623", id: 10623 },
+          ],
+          links: [
+            { url: "https://github.com/example/repo2", displayName: "GitHub Repository" },
+          ],
+          fileInfo: [
+            { name: "README.md", size: "11.7 KB", dateModified: "2024-10-01 12:15:00" },
+          ],
+        },
+      ];
+
+      setSubmissions(data);
+      setFilteredSubmissions(data);
+    };
+
+    fetchSubmissions();
+  }, []);
+
+  const handleGradeClick = (id: number) => {
+    console.log(`Assign Grade clicked for submission ID ${id}`);
+  };
+
+  const handleAssignmentChange = (e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement>) => {
+    const selectedAssignment = e.target.value;
+    setAssignmentFilter(selectedAssignment);
+    if (selectedAssignment) {
+      setFilteredSubmissions(submissions.filter(sub => sub.assignment === selectedAssignment));
+    } else {
+      setFilteredSubmissions(submissions);
+    }
+  };
+
+  return (
+    <Container className="mt-4">
+      <Row>
+        <Col md={3}>
+          <h1>Submissions</h1>
+          <hr />
+          <Form.Group controlId="assignmentFilter">
+            <Form.Label>Filter by Assignment</Form.Label>
+            <Form.Control as="select" value={assignmentFilter} onChange={(e) => handleAssignmentChange(e as any)}>
+              <option value="">All Assignments</option>
+              {assignments.map((assignment, index) => (
+                <option key={index} value={assignment}>{assignment}</option>
+              ))}
+            </Form.Control>
+          </Form.Group>
+        </Col>
+
+        <Col md={9}>
+          <SubmissionList submissions={filteredSubmissions} onGradeClick={handleGradeClick} />
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default SubmissionView;

--- a/src/pages/ViewTeamGrades/grades.scss
+++ b/src/pages/ViewTeamGrades/grades.scss
@@ -227,7 +227,7 @@
 .container {
   display: flex;
   justify-content: space-between; /* Adjust as needed */
-  width: 80%; /* Ensure the container takes up the full width */
+  width: 100%; /* Ensure the container takes up the full width */
 }
 
 


### PR DESCRIPTION
### Summary

This PR adds the submission list view which can be accessed by selecting the `Assignments` link in the top navigation bar.

Currently the list populates using dummy data since the back-end reimplementation doesn't currently keep up with submissions for a given assignment.

### Changes

- The submission list view now contains the same information that the submission view in expertiza contains.
- The table sorts have been removed from all columns except for the team name column since it didn't make sense to sort by the other column values.
- A filter has been added to the view to only display submissions for a selected assignment
- The table is now supports pagination

